### PR TITLE
Replace disk-space warning with a live per-image size table

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -76,8 +76,9 @@ The error looks like this:
 
 The machine running your submission has 60 GB of disk, and that space is shared between your
 replication package (including everything your code writes) and the software image it runs
-in. Large images consume a substantial part of it — the MATLAB / Dynare image alone is about
-15 GB.
+in. Large images consume a substantial part of it — see the
+[size considerations table](step0-prepare.md#size-considerations) for how much room typical
+images leave free.
 
 Things that help:
 

--- a/docs/step0-prepare.md
+++ b/docs/step0-prepare.md
@@ -1,3 +1,10 @@
+---
+kernelspec:
+  display_name: Python 3
+  language: python
+  name: python3
+---
+
 # Preparing a Compatible Replication Package
 
 ### You should not include any data that you are not allowed to upload to third-party systems
@@ -92,8 +99,63 @@ The single-application requirement means you cannot call one application from an
 
 ::::
 
+### Size considerations
 
+Software images can be large, and they share the same 60 GB disk as your replication
+package (see [Hardware capabilities](system.md#hardware-capabilities)). The table below is
+pulled live from Docker Hub each time this page is built, and shows the download size and
+remaining free space for the most recently added version of a few representative images
+(see [Available Software](images.md) for the full, curated list):
 
+```{code-cell} python
+:tags: ["remove-input"]
+
+import yaml
+import requests
+from IPython.display import Markdown, display
+
+DISK_GB = 60  # total disk available to a submission, in decimal GB
+
+# A handful of representative images, not the full curated list (see images.md for that).
+SAMPLE_IMAGES = [
+    ("rocker/verse", "R"),
+    ("rocker/geospatial", "R"),
+    ("dynare/dynare", "MATLAB"),
+    ("dataeditors/stata19_5-mp-i-python", "Stata"),
+    ("dataeditors/stata19-mp", "Stata"),
+]
+
+repos_url = "https://raw.githubusercontent.com/SIVACOR/sivacor-repo-choice/main/allowed_repos.yaml"
+allowed = yaml.safe_load(requests.get(repos_url).text)
+
+rows = []
+for image_name, software in SAMPLE_IMAGES:
+    tag = str(allowed[image_name][0])  # first entry is the most recently added tag
+    tag_info = requests.get(
+        f"https://hub.docker.com/v2/repositories/{image_name}/tags/{tag}/"
+    ).json()
+    size_bytes = next(
+        (img["size"] for img in tag_info["images"] if img["architecture"] == "amd64"),
+        tag_info["full_size"],
+    )
+    size_gb = size_bytes / 1e9
+    rows.append((software, f"{image_name}:{tag}", size_gb, DISK_GB - size_gb))
+
+table = "| Software | Image | Download size | Free space after download\\* |\n"
+table += "|---|---|---:|---:|\n"
+for software, image_tag, size_gb, free_gb in rows:
+    table += f"| {software} | `{image_tag}` | {size_gb:.1f} GB | {free_gb:.1f} GB |\n"
+
+display(Markdown(table))
+```
+
+\* Docker Hub reports the compressed download size; the image takes up somewhat more room
+once it is unpacked on disk, so treat this as an upper bound on the space actually left over
+for your replication package.
+
+If free space runs low, the run is stopped and you will see an error saying the submission
+ran out of disk space — see the
+[FAQ](faq.md#my-job-failed-saying-it-ran-out-of-disk-space) for what to do about it.
 
 
 ### Prepare a ZIP or tar.gz file

--- a/docs/step0-prepare.md
+++ b/docs/step0-prepare.md
@@ -17,6 +17,7 @@ If you have data that you are allowed to upload, but not publish, see [the next 
 
 
 
+(excluding-files-from-final-package)=
 ### Excluding files from final package
 
 The final digitally signed replication package contains all data as originally included. If you need to remove files because you do not have redistribution rights, or large intermediate files, you can include a file named `.sivacorignore` (note the leading dot!) at the root of your project to exclude files or directories before the final replicated package is created. It follows the same pattern rules as [`.gitignore`](https://git-scm.com/docs/gitignore), so you can use [glob patterns](https://en.wikipedia.org/wiki/Glob_%28programming%29), negations, and directory-specific rules.
@@ -90,7 +91,7 @@ Guidance for portable dependencies for Stata is provided [at Step 3](https://aea
 
 ### Your replication package only uses a single software application per step
 
-Each step of a SIVACOR submission only supports a single software application (e.g., Stata, R, Python), as encapsulated by containers. If your replication requires multiple applications, you will need to configure separate runs. However, your package itself can include the code for multiple applications, and you can chain them together in a highly simplified workflow system at submission, see [instructions in Step 2](step2-choosing-image.md#chained-runs-steps).
+Each step of a SIVACOR submission only supports a single software application (e.g., Stata, R, Python), as encapsulated by containers. If your replication requires multiple applications, you will need to configure separate runs. However, your package itself can include the code for multiple applications, and you can chain them together in a highly simplified workflow system at submission, see [instructions in Step 2](#chained-runs-steps).
 
 ::::{admonition} Additional information
 :class: dropdown tip
@@ -102,19 +103,28 @@ The single-application requirement means you cannot call one application from an
 ### Size considerations
 
 Software images can be large, and they share the same 60 GB disk as your replication
-package (see [Hardware capabilities](system.md#hardware-capabilities)). The table below is
-pulled live from Docker Hub each time this page is built, and shows the download size and
-remaining free space for the most recently added version of a few representative images
-(see [Available Software](images.md) for the full, curated list):
+package (see [Hardware capabilities](system.md#hardware-capabilities)). About 4.5 GB of that
+disk is already taken by the operating system and the SIVACOR harness itself, leaving roughly
+55.5 GB for the image plus your package. The table below is pulled live from Docker Hub each
+time this page is built, and shows, for the most recently added version of a few
+representative images, how much is downloaded, how much room that takes once unpacked, and
+what is left over for you (see [Available Software](images.md) for the full, curated list):
 
 ```{code-cell} python
 :tags: ["remove-input"]
 
 import yaml
 import requests
-from IPython.display import Markdown, display
+from IPython.display import HTML, display
 
-DISK_GB = 60  # total disk available to a submission, in decimal GB
+DISK_GB = 60  # total disk on the machine, in decimal GB
+OVERHEAD_GB = 4.5  # operating system + SIVACOR harness
+
+# Docker Hub reports the *compressed* size of the layers; `docker pull` unpacks them, and the
+# compressed copies are not kept. Measured unpacked/compressed ratios for the images below
+# range from 2.05x (dataeditors/stata19_5-mp) to 2.95x (rocker/geospatial), so 3x is used as a
+# deliberately conservative ceiling rather than a best estimate.
+UNPACK_FACTOR = 3
 
 # A handful of representative images, not the full curated list (see images.md for that).
 SAMPLE_IMAGES = [
@@ -139,19 +149,48 @@ for image_name, software in SAMPLE_IMAGES:
         tag_info["full_size"],
     )
     size_gb = size_bytes / 1e9
-    rows.append((software, f"{image_name}:{tag}", size_gb, DISK_GB - size_gb))
+    unpacked_gb = size_gb * UNPACK_FACTOR
+    rows.append(
+        (
+            software,
+            f"{image_name}:{tag}",
+            size_gb,
+            unpacked_gb,
+            DISK_GB - OVERHEAD_GB - unpacked_gb,
+        )
+    )
 
-table = "| Software | Image | Download size | Free space after download\\* |\n"
-table += "|---|---|---:|---:|\n"
-for software, image_tag, size_gb, free_gb in rows:
-    table += f"| {software} | `{image_tag}` | {size_gb:.1f} GB | {free_gb:.1f} GB |\n"
+# MyST does not render `text/markdown` outputs, so emit HTML directly.
+L, R = 'style="text-align:left"', 'style="text-align:right"'
+table = (
+    "<table>\n<thead><tr>"
+    f"<th {L}>Software</th><th {L}>Image</th>"
+    f"<th {R}>Download size</th>"
+    f"<th {R}>Space used on disk*</th>"
+    f"<th {R}>Free space for your package*</th>"
+    "</tr></thead>\n<tbody>\n"
+)
+for software, image_tag, size_gb, unpacked_gb, free_gb in rows:
+    table += (
+        f"<tr><td {L}>{software}</td><td {L}><code>{image_tag}</code></td>"
+        f"<td {R}>{size_gb:.1f} GB</td>"
+        f"<td {R}>{unpacked_gb:.1f} GB</td>"
+        f"<td {R}>{free_gb:.1f} GB</td></tr>\n"
+    )
+table += "</tbody>\n</table>"
 
-display(Markdown(table))
+display(HTML(table))
 ```
 
-\* Docker Hub reports the compressed download size; the image takes up somewhat more room
-once it is unpacked on disk, so treat this as an upper bound on the space actually left over
-for your replication package.
+\* Docker Hub reports the *compressed* download size, but an image is unpacked as it is
+downloaded, and takes up roughly two to three times its download size once on disk. The
+"space used on disk" column therefore multiplies the download size by three — a deliberately
+conservative ceiling, so the real figure is usually a few GB lower. Free space is then 60 GB
+minus the 4.5 GB used by the system and harness, minus that unpacked size.
+
+Bear in mind that your replication package also needs room for more than one copy of itself:
+the archive you upload, the workspace it is extracted into, and anything your code writes all
+share what is left.
 
 If free space runs low, the run is stopped and you will see an error saying the submission
 ran out of disk space — see the

--- a/docs/step2-choosing-image.md
+++ b/docs/step2-choosing-image.md
@@ -24,6 +24,7 @@ Please be sure to use the proper case (`main.do` is not the same as `Main.do`) a
 
 :::
 
+(chained-runs-steps)=
 ## Optional chained runs (steps)
 
 You can chain multiple runs together, by selecting the `+ ADD STEP` button. The runs will be run in separate containers. Each run inherits the workspace modified by the previous run, so the output of one run will be made available as input to the next run.

--- a/docs/step4-download.md
+++ b/docs/step4-download.md
@@ -10,7 +10,7 @@ You can also download a `Workflow definition` — a small YAML file describing t
 versions and main files this run used. It is not part of the signed package; it is there so
 you (or a colleague) can reproduce the same setup later by importing it on the submission
 page, instead of filling the form in by hand. See
-[Optional chained runs](step2-choosing-image.md#optional-chained-runs-steps). It is offered
+[Optional chained runs](#chained-runs-steps). It is offered
 for failed runs too, which is useful when you want to fix your code and run exactly the same
 configuration again.
 

--- a/docs/system.md
+++ b/docs/system.md
@@ -17,14 +17,9 @@ carried over from one submission to the next.
 Your analysis is given the whole machine — SIVACOR does not place additional CPU or
 memory limits on the container.
 
-:::{warning}
-
-The 60 GB of disk must hold **both** your replication package (including everything your
-code writes) **and** the software image it runs in. Those images are large: the MATLAB /
-Dynare image alone is about 15 GB. If free space runs low, the run is stopped and you will
-see an error saying the submission ran out of disk space.
-
-:::
+The 60 GB of disk is shared between your replication package and the software image it runs
+in — see [Size considerations](step0-prepare.md#size-considerations) when preparing your
+package.
 
 ### Limits
 


### PR DESCRIPTION
Adds a MyST code-cell to step0-prepare.md that pulls the allowed image list live from sivacor-repo-choice and queries the Docker Hub API for the download size of the latest rocker/verse, rocker/geospatial, dynare/dynare, dataeditors/stata19_5-mp-i-python, and dataeditors/stata19-mp images, computing free space left on the 60 GB disk for each. system.md now only states the raw hardware parameters, with a pointer to the new table; faq.md links to it too.