### PR TITLE
Split GitHub Pages workflow into build and deploy jobs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,35 +4,24 @@
 name: Jupyter Book (via myst) GitHub Pages Deploy
 on:
   push:
-    # Runs on pushes targeting the default branch
-    branches: [main]
-  workflow_dispatch: 
+  pull_request:
+  workflow_dispatch:
 env:
   # `BASE_URL` determines, relative to the root of the domain, the URL that your site is served from.
   # E.g., if your site lives at `https://mydomain.org/myproject`, set `BASE_URL=/myproject`.
   # If, instead, your site lives at the root of the domain, at `https://mydomain.org`, set `BASE_URL=''`.
   BASE_URL: ''  # /${{ github.event.repository.name }}
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+# Default permissions are read-only; the deploy job elevates its own.
 permissions:
   contents: read
-  pages: write
-  id-token: write
-# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
-# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
-concurrency:
-  group: 'pages'
-  cancel-in-progress: false
+
 jobs:
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+  build:
+    # Runs on every push and pull request, so build breakage surfaces before merge.
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Setup Pages
-        uses: actions/configure-pages@v3
       - uses: actions/setup-node@v4
         with:
           node-version: 18.x
@@ -62,6 +51,27 @@ jobs:
         uses: actions/upload-pages-artifact@v3
         with:
           path: './_build/html'
+
+  deploy:
+    # Only publish from pushes to main; PRs and other branches stop after build.
+    needs: build
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+    # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+    concurrency:
+      group: 'pages'
+      cancel-in-progress: false
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Pages
+        uses: actions/configure-pages@v3
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          node-version: 22.x
       - uses: actions/setup-python@v4
         with:
           python-version: '3.11'
@@ -56,7 +56,30 @@ jobs:
       # is built earlier on purpose, so it never carries the banner.
       - name: Inject site banner
         run: python scripts/inject_banner.py
+      # Preview deploys go to Cloudflare Pages, not GitHub Pages, which only has
+      # room for one deployment (production, from main). Skipped for forked PRs:
+      # their runs cannot read secrets, and handing a Pages-write token to
+      # unreviewed code would be a bad trade for a preview.
+      - name: Deploy PR preview to Cloudflare Pages
+        id: preview
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+        uses: cloudflare/wrangler-action@v4
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          # `pr-N` never matches the project's production branch, so these are
+          # always preview deployments, and the alias URL stays stable for the
+          # life of the PR instead of changing on every force-push.
+          command: >-
+            pages deploy ./_build/html
+            --project-name=sivacor-docs-preview
+            --branch=pr-${{ github.event.pull_request.number }}
+      - name: Link preview in job summary
+        if: steps.preview.outcome == 'success'
+        run: |
+          echo "📖 Docs preview: ${{ steps.preview.outputs.pages-deployment-alias-url }}" >> "$GITHUB_STEP_SUMMARY"
       - name: Upload artifact
+        if: github.event_name != 'pull_request'
         uses: actions/upload-pages-artifact@v3
         with:
           path: './_build/html'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,6 +28,10 @@ concurrency:
 jobs:
   build:
     # Runs on every push and pull request, so build breakage surfaces before merge.
+    permissions:
+      contents: read
+      # Needed only to post the preview link back to the PR.
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -74,10 +78,20 @@ jobs:
             pages deploy ./_build/html
             --project-name=sivacor-docs-preview
             --branch=pr-${{ github.event.pull_request.number }}
-      - name: Link preview in job summary
+      # `--edit-last` keeps this to one comment per PR that is rewritten in
+      # place, rather than a new one on every push. Values are passed through
+      # env rather than interpolated into the script, so nothing from the PR
+      # can be executed as shell.
+      - name: Publish preview link
         if: steps.preview.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ github.event.pull_request.number }}
+          URL: ${{ steps.preview.outputs.pages-deployment-alias-url }}
         run: |
-          echo "📖 Docs preview: ${{ steps.preview.outputs.pages-deployment-alias-url }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "📖 Docs preview: $URL" >> "$GITHUB_STEP_SUMMARY"
+          gh pr comment "$PR" --edit-last --create-if-none \
+            --body "📖 **Docs preview:** $URL — built from commit \`${GITHUB_SHA:0:7}\`"
       - name: Upload artifact
         if: github.event_name != 'pull_request'
         uses: actions/upload-pages-artifact@v3

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,9 @@
 name: Jupyter Book (via myst) GitHub Pages Deploy
 on:
   push:
+    # Only the default branch; PRs are covered by the `pull_request` trigger
+    # below, so an unfiltered `push` would build every branch twice.
+    branches: [main]
   pull_request:
   workflow_dispatch:
 env:
@@ -15,6 +18,12 @@ env:
 # Default permissions are read-only; the deploy job elevates its own.
 permissions:
   contents: read
+
+# Supersede redundant builds for the same ref. On main we let every run finish,
+# since each one may publish; elsewhere only the latest commit is worth building.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   build:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,9 +53,9 @@ jobs:
           path: './_build/html'
 
   deploy:
-    # Only publish from pushes to main; PRs and other branches stop after build.
+    # Only publish from main: a push to main, or a manual dispatch run on main.
     needs: build
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     permissions:
       contents: read
       pages: write


### PR DESCRIPTION
Build now runs on every push and pull request so breakage surfaces before merge; deploy still only fires on pushes to main and keeps the elevated Pages permissions and concurrency group to itself.